### PR TITLE
Updated license text, added a check for too-large ensembles

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Jeffrey Johnson
+James Overfelt

--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,8 @@
-************************************************************************
-  Skywalker: Copyright 2021, Cohere Consulting, LLC and
-             National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+Copyright (c) 2021,
+National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 
-Copyright pending. Under provisional terms of Contract DE-NA0003525 with NTESS,
-the U.S. Government retains certain rights in this software.
+Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+retains certain rights in this software.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -31,6 +30,3 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-************************************************************************

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,57 @@
+Skywalker uses the klib and libyaml libraries, which are covered by their
+respective licenses. Their source code can be found in the ext/ directory
+after running
+
+git submodule update --init --recursive
+
+====
+klib
+====
+
+The MIT License
+
+Copyright (c) 2008-     Attractive Chaos <attractor@live.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=======
+libyaml
+=======
+
+Copyright (c) 2017-2020 Ingy döt Net
+Copyright (c) 2006-2016 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/include/skywalker.h.in
+++ b/include/skywalker.h.in
@@ -1,9 +1,9 @@
-// ************************************************************************
-// Skywalker: Copyright 2021, Cohere Consulting, LLC and
-//            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//-------------------------------------------------------------------------
+// Copyright (c) 2021,
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 //
-// Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-// NTESS, the U.S. Government retains certain rights in this software.
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+// retains certain rights in this software.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-// ************************************************************************
+//-------------------------------------------------------------------------
 
 #ifndef SKYWALKER_H
 #define SKYWALKER_H

--- a/include/skywalker.h.in
+++ b/include/skywalker.h.in
@@ -67,6 +67,7 @@ typedef enum sw_error_code_t {
   SW_TOO_MANY_LATTICE_PARAMS,// the specified lattice ensemble has > 7 parameters
   SW_INVALID_ENUMERATION,    // the specified enumeration ensemble has an invalid
                              // enumeration
+  SW_ENSEMBLE_TOO_LARGE,     // the specified ensemble doesn't fit into memory
   SW_EMPTY_ENSEMBLE          // the specified ensemble has no members
 } sw_error_code_t;
 

--- a/include/skywalker.hpp
+++ b/include/skywalker.hpp
@@ -1,9 +1,9 @@
-// ************************************************************************
-// Skywalker: Copyright 2021, Cohere Consulting, LLC and
-//            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//-------------------------------------------------------------------------
+// Copyright (c) 2021,
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 //
-// Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-// NTESS, the U.S. Government retains certain rights in this software.
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+// retains certain rights in this software.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-// ************************************************************************
+//-------------------------------------------------------------------------
 
 #ifndef SKYWALKER_HPP
 #define SKYWALKER_HPP

--- a/src/py2ncl
+++ b/src/py2ncl
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
-# ************************************************************************
-# Skywalker: Copyright 2021, Cohere Consulting, LLC and
-#            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+# ------------------------------------------------------------------------
+# Copyright (c) 2021,
+# National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 #
-# Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-# NTESS, the U.S. Government retains certain rights in this software.
+# Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+# retains certain rights in this software.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -33,9 +33,7 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-# Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-# ************************************************************************
+# ------------------------------------------------------------------------
 
 # This script translates the output data in the given file to a text format
 # usable by the NCAR Command Language (NCL). For more information about NCL, see

--- a/src/skywalker.F90
+++ b/src/skywalker.F90
@@ -1,9 +1,9 @@
-! ************************************************************************
-! Skywalker: Copyright 2021, Cohere Consulting, LLC and
-!            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+! -------------------------------------------------------------------------
+! Copyright (c) 2021,
+! National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 !
-! Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-! NTESS, the U.S. Government retains certain rights in this software.
+! Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+! retains certain rights in this software.
 !
 ! Redistribution and use in source and binary forms, with or without
 ! modification, are permitted provided that the following conditions are
@@ -33,7 +33,7 @@
 ! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 !
 ! Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-! ************************************************************************
+! -------------------------------------------------------------------------
 
 ! This module contains data structures that allow Fortran modules to access
 ! skywalker's ensemble input and output data.

--- a/src/skywalker.c
+++ b/src/skywalker.c
@@ -1038,7 +1038,7 @@ static sw_build_result_t build_lattice_ensemble(yaml_data_t yaml_data) {
   if (!result.inputs) {
     result.error_code = SW_ENSEMBLE_TOO_LARGE;
     result.error_message =
-      new_string("The given lattice ensemble (%d members) is too large to fit "
+      new_string("The given lattice ensemble (%zd members) is too large to fit "
                  "into memory.\n", result.num_inputs);
   } else {
     for (size_t l = 0; l < result.num_inputs; ++l) {

--- a/src/skywalker.c
+++ b/src/skywalker.c
@@ -1035,13 +1035,20 @@ static sw_build_result_t build_lattice_ensemble(yaml_data_t yaml_data) {
 
   // Build a list of inputs corresponding to all the traversed parameters.
   result.inputs = malloc(sizeof(sw_input_t) * result.num_inputs);
-  for (size_t l = 0; l < result.num_inputs; ++l) {
-    result.inputs[l].params = kh_init(param_map);
-    result.inputs[l].array_params = kh_init(array_param_map);
-    assign_single_valued_params(yaml_data, &result.inputs[l]);
-    assign_single_valued_array_params(yaml_data, &result.inputs[l]);
-    if (num_lattice_params > 0) {
-      assign_lattice_params[num_lattice_params](yaml_data, l, &result.inputs[l]);
+  if (!result.inputs) {
+    result.error_code = SW_ENSEMBLE_TOO_LARGE;
+    result.error_message =
+      new_string("The given lattice ensemble (%d members) is too large to fit "
+                 "into memory.\n", result.num_inputs);
+  } else {
+    for (size_t l = 0; l < result.num_inputs; ++l) {
+      result.inputs[l].params = kh_init(param_map);
+      result.inputs[l].array_params = kh_init(array_param_map);
+      assign_single_valued_params(yaml_data, &result.inputs[l]);
+      assign_single_valued_array_params(yaml_data, &result.inputs[l]);
+      if (num_lattice_params > 0) {
+        assign_lattice_params[num_lattice_params](yaml_data, l, &result.inputs[l]);
+      }
     }
   }
 

--- a/src/skywalker.c
+++ b/src/skywalker.c
@@ -1,9 +1,9 @@
-// ************************************************************************
-// Skywalker: Copyright 2021, Cohere Consulting, LLC and
-//            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//-------------------------------------------------------------------------
+// Copyright (c) 2021,
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 //
-// Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-// NTESS, the U.S. Government retains certain rights in this software.
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+// retains certain rights in this software.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-// ************************************************************************
+//-------------------------------------------------------------------------
 
 #include <skywalker.h>
 

--- a/src/tests/array_param_test.F90
+++ b/src/tests/array_param_test.F90
@@ -1,9 +1,9 @@
-! ************************************************************************
-! Skywalker: Copyright 2021, Cohere Consulting, LLC and
-!            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+! -------------------------------------------------------------------------
+! Copyright (c) 2021,
+! National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 !
-! Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-! NTESS, the U.S. Government retains certain rights in this software.
+! Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+! retains certain rights in this software.
 !
 ! Redistribution and use in source and binary forms, with or without
 ! modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 ! LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ! NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-!
-! Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-! ************************************************************************
+! -------------------------------------------------------------------------
 
 ! This program tests Skywalker's Fortran 90 interface and its support for
 ! array parameters.

--- a/src/tests/array_param_test.c
+++ b/src/tests/array_param_test.c
@@ -1,9 +1,9 @@
-// ************************************************************************
-// Skywalker: Copyright 2021, Cohere Consulting, LLC and
-//            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//-------------------------------------------------------------------------
+// Copyright (c) 2021,
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 //
-// Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-// NTESS, the U.S. Government retains certain rights in this software.
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+// retains certain rights in this software.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-// ************************************************************************
+//-------------------------------------------------------------------------
 
 // This program tests Skywalker's C interface with an ensemble defined by an
 // enumeration.

--- a/src/tests/array_param_test.cpp
+++ b/src/tests/array_param_test.cpp
@@ -1,9 +1,9 @@
-// ************************************************************************
-// Skywalker: Copyright 2021, Cohere Consulting, LLC and
-//            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//-------------------------------------------------------------------------
+// Copyright (c) 2021,
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 //
-// Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-// NTESS, the U.S. Government retains certain rights in this software.
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+// retains certain rights in this software.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-// ************************************************************************
+//-------------------------------------------------------------------------
 
 // This program tests Skywalker's C++ interface and its support for array
 // parameters.

--- a/src/tests/enumeration_test.F90
+++ b/src/tests/enumeration_test.F90
@@ -1,9 +1,9 @@
-! ************************************************************************
-! Skywalker: Copyright 2021, Cohere Consulting, LLC and
-!            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+! -------------------------------------------------------------------------
+! Copyright (c) 2021,
+! National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 !
-! Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-! NTESS, the U.S. Government retains certain rights in this software.
+! Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+! retains certain rights in this software.
 !
 ! Redistribution and use in source and binary forms, with or without
 ! modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 ! LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ! NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-!
-! Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-! ************************************************************************
+! -------------------------------------------------------------------------
 
 ! This program tests Skywalker's Fortran 90 interface with a user-defined
 ! configuration that uses an "enumeration" ensemble.

--- a/src/tests/enumeration_test.c
+++ b/src/tests/enumeration_test.c
@@ -1,9 +1,9 @@
-// ************************************************************************
-// Skywalker: Copyright 2021, Cohere Consulting, LLC and
-//            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//-------------------------------------------------------------------------
+// Copyright (c) 2021,
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 //
-// Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-// NTESS, the U.S. Government retains certain rights in this software.
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+// retains certain rights in this software.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-// ************************************************************************
+//-------------------------------------------------------------------------
 
 // This program tests Skywalker's C interface with an ensemble defined by an
 // enumeration.

--- a/src/tests/enumeration_test.cpp
+++ b/src/tests/enumeration_test.cpp
@@ -1,9 +1,9 @@
-// ************************************************************************
-// Skywalker: Copyright 2021, Cohere Consulting, LLC and
-//            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//-------------------------------------------------------------------------
+// Copyright (c) 2021,
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 //
-// Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-// NTESS, the U.S. Government retains certain rights in this software.
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+// retains certain rights in this software.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-// ************************************************************************
+//-------------------------------------------------------------------------
 
 // This program tests Skywalker's C++ interface with an ensemble defined by an
 // enumeration.

--- a/src/tests/lattice_test.F90
+++ b/src/tests/lattice_test.F90
@@ -1,9 +1,9 @@
-! ************************************************************************
-! Skywalker: Copyright 2021, Cohere Consulting, LLC and
-!            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+! -------------------------------------------------------------------------
+! Copyright (c) 2021,
+! National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 !
-! Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-! NTESS, the U.S. Government retains certain rights in this software.
+! Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+! retains certain rights in this software.
 !
 ! Redistribution and use in source and binary forms, with or without
 ! modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 ! LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ! NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-!
-! Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-! ************************************************************************
+! -------------------------------------------------------------------------
 
 ! This program tests Skywalker's Fortran 90 interface with a user-defined
 ! configuration.

--- a/src/tests/lattice_test.c
+++ b/src/tests/lattice_test.c
@@ -1,9 +1,9 @@
-// ************************************************************************
-// Skywalker: Copyright 2021, Cohere Consulting, LLC and
-//            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//-------------------------------------------------------------------------
+// Copyright (c) 2021,
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 //
-// Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-// NTESS, the U.S. Government retains certain rights in this software.
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+// retains certain rights in this software.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-// ************************************************************************
+//-------------------------------------------------------------------------
 
 // This program tests Skywalker's C interface with a lattice ensemble.
 

--- a/src/tests/lattice_test.cpp
+++ b/src/tests/lattice_test.cpp
@@ -1,9 +1,9 @@
-// ************************************************************************
-// Skywalker: Copyright 2021, Cohere Consulting, LLC and
-//            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//-------------------------------------------------------------------------
+// Copyright (c) 2021,
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 //
-// Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-// NTESS, the U.S. Government retains certain rights in this software.
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+// retains certain rights in this software.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-// ************************************************************************
+//-------------------------------------------------------------------------
 
 // This program tests Skywalker's C++ interface with a lattice ensemble.
 

--- a/src/tests/validation_test.c
+++ b/src/tests/validation_test.c
@@ -1,9 +1,9 @@
-// ************************************************************************
-// Skywalker: Copyright 2021, Cohere Consulting, LLC and
-//            National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//-------------------------------------------------------------------------
+// Copyright (c) 2021,
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS).
 //
-// Copyright pending. Under provisional terms of Contract DE-NA0003525 with
-// NTESS, the U.S. Government retains certain rights in this software.
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+// retains certain rights in this software.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -31,9 +31,7 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact Jeffrey Johnson (jeff@cohere-llc.com)
-// ************************************************************************
+//-------------------------------------------------------------------------
 
 // This program tests Skywalker's ability to validate input.
 


### PR DESCRIPTION
This PR brings Skywalker's license into compliance with the open source release policy specified by Sandia National Labs.