### PR TITLE
Updated C++ tests to use std::abs instead of fabs.

### DIFF
--- a/src/tests/array_param_test.cpp
+++ b/src/tests/array_param_test.cpp
@@ -40,8 +40,7 @@
 
 #include <cassert>
 #include <iostream>
-#include <string.h>
-#include <tgmath.h>
+#include <cstring>
 
 void usage(const std::string& prog_name) {
   std::cerr << prog_name << ": usage:" << std::endl;
@@ -50,7 +49,7 @@ void usage(const std::string& prog_name) {
 }
 
 static bool approx_equal(sw_real_t x, sw_real_t y) {
-  return (fabs(x - y) < 1e-14);
+  return (std::abs(x - y) < 1e-14);
 }
 
 using namespace skywalker;

--- a/src/tests/enumeration_test.cpp
+++ b/src/tests/enumeration_test.cpp
@@ -40,8 +40,7 @@
 
 #include <cassert>
 #include <iostream>
-#include <string.h>
-#include <tgmath.h>
+#include <cstring>
 
 void usage(const std::string& prog_name) {
   std::cerr << prog_name << ": usage:" << std::endl;
@@ -50,7 +49,7 @@ void usage(const std::string& prog_name) {
 }
 
 static bool approx_equal(sw_real_t x, sw_real_t y) {
-  return (fabs(x - y) < 1e-14);
+  return (std::abs(x - y) < 1e-14);
 }
 
 using namespace skywalker;

--- a/src/tests/lattice_test.cpp
+++ b/src/tests/lattice_test.cpp
@@ -39,8 +39,7 @@
 
 #include <cassert>
 #include <iostream>
-#include <string.h>
-#include <tgmath.h>
+#include <cstring>
 
 void usage(const std::string& prog_name) {
   std::cerr << prog_name << ": usage:" << std::endl;
@@ -49,7 +48,7 @@ void usage(const std::string& prog_name) {
 }
 
 static bool approx_equal(sw_real_t x, sw_real_t y) {
-  return (fabs(x - y) < 1e-14);
+  return (std::abs(x - y) < 1e-14);
 }
 
 using namespace skywalker;


### PR DESCRIPTION
@singhbalwinder found some compilation errors building the C++ unit tests with Intel's C++ compiler. This PR fixes those errors.