### PR TITLE
Implement the option to use arrays in the lattice type ensemble.

### DIFF
--- a/src/tests/array_param_test.F90
+++ b/src/tests/array_param_test.F90
@@ -102,14 +102,16 @@ program enumeration_test
 
   ! ensemble information
   ensemble = load_result%ensemble
-  assert(ensemble%size == 11)
+  assert(ensemble%size == 1331)
   do while (ensemble%next(input, output))
     assert(input%has_array("p1"))
     call input%get_array("p1", values)
-    assert(size(values) == 3)
-    assert(approx_equal(values(1), 1.0_swp))
-    assert(approx_equal(values(2), 2.0_swp))
-    assert(approx_equal(values(3), 3.0_swp))
+    assert(size(values) == 4)
+    assert(values(1) >= 1.0_swp);
+    assert(values(1) <= 11.0_swp);
+    assert(approx_equal(values(2), 1.0_swp+values(1)));
+    assert(approx_equal(values(3), 2.0_swp+values(1)));
+    assert(approx_equal(values(4), 3.0_swp+values(1)));
 
     assert(input%has_array("p2"))
     call input%get_array("p2", values)

--- a/src/tests/array_param_test.c
+++ b/src/tests/array_param_test.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
 
   // Ensemble data
   sw_ensemble_t *ensemble = load_result.ensemble;
-  assert(sw_ensemble_size(ensemble) == 11);
+  assert(sw_ensemble_size(ensemble) == 1331);
   sw_input_t *input;
   sw_output_t *output;
   while (sw_ensemble_next(ensemble, &input, &output)) {
@@ -83,10 +83,12 @@ int main(int argc, char **argv) {
     assert(sw_input_has_array(input, "p1"));
     in_array_result = sw_input_get_array(input, "p1");
     assert(in_array_result.error_code == SW_SUCCESS);
-    assert(in_array_result.size == 3);
-    assert(approx_equal(in_array_result.values[0], 1.0));
-    assert(approx_equal(in_array_result.values[1], 2.0));
-    assert(approx_equal(in_array_result.values[2], 3.0));
+    assert(in_array_result.size == 4);
+    assert(in_array_result.values[0] >= 1.0);
+    assert(in_array_result.values[0] <= 11.0);
+    assert(approx_equal(in_array_result.values[1], 1+in_array_result.values[0]));
+    assert(approx_equal(in_array_result.values[2], 2+in_array_result.values[0]));
+    assert(approx_equal(in_array_result.values[3], 3+in_array_result.values[0]));
     assert(in_array_result.error_message == NULL);
 
     assert(sw_input_has_array(input, "p2"));

--- a/src/tests/array_param_test.cpp
+++ b/src/tests/array_param_test.cpp
@@ -41,6 +41,7 @@
 #include <cassert>
 #include <iostream>
 #include <cstring>
+#include <cmath>
 
 void usage(const std::string& prog_name) {
   std::cerr << prog_name << ": usage:" << std::endl;
@@ -71,19 +72,21 @@ int main(int argc, char **argv) {
   // Make sure everything is as it should be.
 
   // Ensemble data
-  assert(ensemble->size() == 11);
+  assert(ensemble->size() == 1331);
   ensemble->process([](const Input& input, Output& output) {
     // Fixed parameters
     assert(input.has_array("p1"));
     auto p1 = input.get_array("p1");
-    assert(p1.size() == 3);
-    assert(approx_equal(p1[0], 1.0));
-    assert(approx_equal(p1[1], 2.0));
-    assert(approx_equal(p1[2], 3.0));
+    assert(p1.size() == 4);
+    assert(p1[0] >= 1.0);
+    assert(p1[0] <= 11.0);
+    assert(approx_equal(p1[1], 1+p1[0]));
+    assert(approx_equal(p1[2], 2+p1[0]));
+    assert(approx_equal(p1[3], 3+p1[0]));
 
     assert(input.has_array("p2"));
     auto p2 = input.get_array("p2");
-    assert(p1.size() == 3);
+    assert(p2.size() == 3);
     assert(approx_equal(p2[0], 4.0));
     assert(approx_equal(p2[1], 5.0));
     assert(approx_equal(p2[2], 6.0));

--- a/src/tests/array_param_test.yaml
+++ b/src/tests/array_param_test.yaml
@@ -1,6 +1,6 @@
 # This input file tests Skywalker's support for array parameters.
 
-type: enumeration
+type: lattice
 
 settings:
   param1: hello
@@ -8,7 +8,7 @@ settings:
   param3: 3.14159265357
 
 input:
-  p1: [[1, 2, 3]]
+  p1: [[1, 2, 3, 4],[11,12,13,14],[1,1,1,1]]
   p2: [[4, 5, 6]]
   p3: 3
   tick:        [0, 10, 1] # linear spacing from 0 to 10 in steps of 1.

--- a/src/tests/enumeration_test.cpp
+++ b/src/tests/enumeration_test.cpp
@@ -41,6 +41,7 @@
 #include <cassert>
 #include <iostream>
 #include <cstring>
+#include <cmath>
 
 void usage(const std::string& prog_name) {
   std::cerr << prog_name << ": usage:" << std::endl;

--- a/src/tests/lattice_test.cpp
+++ b/src/tests/lattice_test.cpp
@@ -40,6 +40,7 @@
 #include <cassert>
 #include <iostream>
 #include <cstring>
+#include <cmath>
 
 void usage(const std::string& prog_name) {
   std::cerr << prog_name << ": usage:" << std::endl;


### PR DESCRIPTION
Like scalar lattice type, there has to be exactly three arrays
all of the same length.  Each entry is treated as a lattice
variable and the number of steps is the minimum over all of
the entries.

Added a test to demonstrate.