### PR TITLE
Revised the set of rules used to expand 3-item lists of values.

### DIFF
--- a/docs/input.md
+++ b/docs/input.md
@@ -166,17 +166,22 @@ How does Skywalker know this isn't a list containing the temperatures 230.15 K,
 300.15 K, and 1 K? It uses a set of simple rules to determine how to interpret
 these values.
 
-Lists that satisfy all of these properties are expanded into uniformly spaced
-sets of values:
+A list with values `[v1, v2, v3]` that satisfies the following properties is
+expanded into a uniformly spaced set of values between `v1` and `v2` with
+spacing `v3`:
 
-* The list contains 3 values
-* The first value is less than the second value
-* The third value is less than the second value
+* `v1 < v2` and `v3 < v2`, **OR**
+* `v1 < v2 < 0` and `|v3| < |v2 - v1|`.
 
 All other lists are interpreted as lists containing 3 values.
 
-These rules may seem arbitrary, but in practice, they will never prevent you
-from doing what you need to do.
+These rules handle most cases of interest, but there remain some ambiguous
+sequences that Skywalker does not expand. For example, the list
+`[-11, 1, 2]` could be interpreted as the uniformly-spaced set of values
+`[-11, -9, -7, -5, -3, -1, 1]`, but it is also an ascending set of 3 values,
+so Skywalker doesn't expand it. Because this expanѕion feature is intended as a
+convenience, you can always explicitly perform the expanѕion yourself when you
+create an input file.
 
 ### Logarithmic Spacing
 

--- a/src/skywalker.c
+++ b/src/skywalker.c
@@ -712,7 +712,11 @@ static void postprocess_params(khash_t(yaml_param_map) **params,
       sw_real_t val0 = kv_A(values, 0),
                 val1 = kv_A(values, 1),
                 val2 = kv_A(values, 2);
-      if ((val0 < val1) && (val2 < val1)) { // expand!
+      bool is_non_negative_sequence =
+        ((val0 >= 0) && (val0 < val1) && (val2 <= val1));
+      bool is_negative_sequence =
+        ((val0 < 0) && (val1 < 0) && (fabs(val2) < fabs(val1 - val0)));
+      if (is_non_negative_sequence || is_negative_sequence) {
         real_vec_t expanded_values;
         kv_init(expanded_values);
         size_t size = (size_t)(ceil((val1 - val0) / val2) + 1);

--- a/src/tests/enumerated_test.yaml
+++ b/src/tests/enumerated_test.yaml
@@ -16,4 +16,5 @@ input:
   enumerated:
     tick:        [0, 10, 1] # linear spacing from 0 to 10 in steps of 1.
     log10(tock): [1, 11, 1] # logarithmic spacing from 10 to 1e11 in powers of 10
+    log10(neg_tock): [-11, -1, 1] # log spacing with negative numbers!
 


### PR DESCRIPTION
This allows the use of negative values in 3-item-list expansions under certain conditions. There are
some ambiguous sequences that aren't expanded. The documentation has been
updated to reflect the new rules.

Fixes #20