### PR TITLE
Skywalker now writes floating point numbers in full precision.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -804,7 +804,7 @@ parameter by calling the appropriate function or subroutine.
     // within the given output instance. This operation cannot fail under normal
     // circumstances.
     void sw_output_set_array(sw_output_t *output, const char *name,
-                             const sw_real_t *values, const size_t *size);
+                             const sw_real_t *values, size_t size);
     ```
 === "C++"
     ``` c++

--- a/include/skywalker.h.in
+++ b/include/skywalker.h.in
@@ -181,7 +181,7 @@ void sw_output_set(sw_output_t *output, const char *name, sw_real_t value);
 // within the given output instance. This operation cannot fail under normal
 // circumstances.
 void sw_output_set_array(sw_output_t *output, const char *name,
-                         const sw_real_t *values, const size_t *size);
+                         const sw_real_t *values, size_t size);
 
 // This type stores the result of an attempt to write ensemble data to a
 // Python module.

--- a/include/skywalker.hpp
+++ b/include/skywalker.hpp
@@ -188,8 +188,7 @@ class Output final {
   // Sets (real-valued) parameters in an array with the given name. This
   // operation cannot fail under normal circumstances.
   void set(const std::string& name, const std::vector<Real> &values) const {
-    const size_t n = values.size();
-    sw_output_set_array(output_, name.c_str(), values.data(), &n);
+    sw_output_set_array(output_, name.c_str(), values.data(), values.size());
   }
 
  private:

--- a/src/skywalker.F90
+++ b/src/skywalker.F90
@@ -240,7 +240,7 @@ module skywalker
       real(c_real), value, intent(in) :: value
     end subroutine
 
-    subroutine sw_output_set_array(output, name, values, size) bind(c)
+    subroutine sw_output_set_array_f90(output, name, values, size) bind(c)
       use iso_c_binding, only: c_ptr, c_size_t
       type(c_ptr), value, intent(in) :: output
       type(c_ptr), value, intent(in) :: name
@@ -505,7 +505,7 @@ contains
     real(c_real), target, intent(in), dimension(:) :: values
     integer(c_size_t)              :: c_values_len
     c_values_len = size(values)
-    call sw_output_set_array(output%ptr, f_to_c_string(name), &
+    call sw_output_set_array_f90(output%ptr, f_to_c_string(name), &
       c_loc(values), c_values_len)
   end subroutine
 

--- a/src/skywalker.c
+++ b/src/skywalker.c
@@ -269,14 +269,14 @@ void sw_output_set(sw_output_t *output, const char *name, sw_real_t value) {
 }
 
 void sw_output_set_array(sw_output_t *output, const char *name,
-                         const sw_real_t* values, const size_t *size) {
+                         const sw_real_t *values, size_t size) {
   const char* n = dup_string(name);
   int ret;
   khiter_t iter = kh_put(array_param_map, output->array_metrics, n, &ret);
   assert(ret == 1);
   real_vec_t array;
   kv_init(array);
-  for (size_t i=0; i<*size; ++i)
+  for (size_t i=0; i<size; ++i)
     kv_push(sw_real_t, array, values[i]); // append
   kh_value(output->array_metrics, iter) = array;
 }
@@ -1265,7 +1265,7 @@ sw_write_result_t sw_ensemble_write(sw_ensemble_t *ensemble,
       khash_t(param_map) *params_i = ensemble->inputs[i].params;
       khiter_t iter = kh_get(param_map, params_i, name);
       sw_real_t value = kh_val(params_i, iter);
-      fprintf(file, "%g, ", value);
+      fprintf(file, "%f, ", value);
     }
     fprintf(file, "]\n");
   }
@@ -1284,7 +1284,7 @@ sw_write_result_t sw_ensemble_write(sw_ensemble_t *ensemble,
       size_t size = kv_size(arrays);
       fprintf(file, "[");
       for (size_t i=0; i<size; ++i)
-        fprintf(file, "%g, ", kv_A(arrays, i));
+        fprintf(file, "%f, ", kv_A(arrays, i));
       fprintf(file, "],");
     }
     fprintf(file, "]\n");
@@ -1308,7 +1308,7 @@ sw_write_result_t sw_ensemble_write(sw_ensemble_t *ensemble,
         if (isnan(value)) {
           fprintf(file, "nan, ");
         } else {
-          fprintf(file, "%g, ", value);
+          fprintf(file, "%f, ", value);
         }
       }
       fprintf(file, "]\n");
@@ -1330,7 +1330,7 @@ sw_write_result_t sw_ensemble_write(sw_ensemble_t *ensemble,
           if (isnan(kv_A(arrays, i))) {
             fprintf(file, "nan, ");
           } else {
-            fprintf(file, "%g, ", kv_A(arrays, i));
+            fprintf(file, "%f, ", kv_A(arrays, i));
           }
         }
         fprintf(file, "],");
@@ -1411,6 +1411,12 @@ void sw_input_get_array_f90(sw_input_t *input, const char *name,
   *error_code = result.error_code;
   *error_message = result.error_message;
 }
+
+void sw_output_set_array_f90(sw_output_t *output, const char *name,
+                             const sw_real_t *values, size_t *size) {
+  sw_output_set_array(output, name, values, *size);
+}
+
 
 void sw_ensemble_write_f90(sw_ensemble_t *ensemble, const char *module_filename,
                           int *error_code, const char **error_message) {

--- a/src/skywalker.c
+++ b/src/skywalker.c
@@ -414,7 +414,7 @@ typedef struct parser_state_t {
 // Returns true if the given input parameter name is valid, false otherwise,
 // based on whether the parameter is an array or a scalar.
 static bool is_valid_input_name(const char *name, bool is_array_value) {
-  assert(name != NULL);
+  assert(name);
 
   // A name must begin with an alphabetical character or an underscore.
   if (!isalpha(name[0]) && (name[0] != '_'))
@@ -456,7 +456,7 @@ static void handle_yaml_event(yaml_event_t *event,
     // settings block
     if (!state->parsing_settings && state->settings_block &&
         (state->settings_block[0] != '\0') && // exclude blank strings
-        strcmp(value, state->settings_block) == 0) {
+        !strcmp(value, state->settings_block)) {
       assert(!state->current_setting);
       data->settings = sw_settings_new();
       state->parsing_settings = true;
@@ -484,17 +484,17 @@ static void handle_yaml_event(yaml_event_t *event,
       }
 
     // input block
-    } else if (!state->parsing_input && strcmp(value, "input") == 0) {
+    } else if (!state->parsing_input && !strcmp(value, "input")) {
       state->parsing_input = true;
     } else if (state->parsing_input) {
       if (!state->parsing_fixed_params &&
           !state->parsing_lattice_params &&
           !state->parsing_enumerated_params) {
-        if (strcmp(value, "fixed") == 0) {
+        if (!strcmp(value, "fixed")) {
           state->parsing_fixed_params = true;
-        } else if (strcmp(value, "lattice") == 0) {
+        } else if (!strcmp(value, "lattice")) {
           state->parsing_lattice_params = true;
-        } else if (strcmp(value, "enumerated") == 0) {
+        } else if (!strcmp(value, "enumerated")) {
           state->parsing_enumerated_params = true;
         } else {
           data->error_code = SW_INVALID_PARAM_TYPE;
@@ -1011,7 +1011,7 @@ static void assign_lattice_params(yaml_data_t yaml_data, size_t l, const size_t 
   }
   size_t n[7];
   for (size_t i = 0; i < m; ++i) {
-    n[i] = (NULL != name[i]) ? kv_size(values[i]) : kv_size(array_values[i]);
+    n[i] = (name[i]) ? kv_size(values[i]) : kv_size(array_values[i]);
   };
   size_t j[7];
   {
@@ -1023,7 +1023,7 @@ static void assign_lattice_params(yaml_data_t yaml_data, size_t l, const size_t 
     j[0] = L;
   }
   for  (int i=0; i<m; ++i) {
-    if (NULL != name[i])
+    if (name[i])
       sw_input_set(input, name[i], kv_A(values[i], j[i]));
     else
       sw_input_set_array(input, array_name[i], kv_A(array_values[i], j[i]));
@@ -1143,7 +1143,7 @@ sw_ensemble_result_t sw_load_ensemble(const char* yaml_file,
   sw_ensemble_result_t result = {.error_code = 0};
 
   // Validate inputs.
-  if (settings_block && (strcmp(settings_block, "input") == 0)) {
+  if (settings_block && (!strcmp(settings_block, "input"))) {
     result.error_code = SW_INVALID_SETTINGS_BLOCK;
     result.error_message = new_string("Invalid settings block name: '%s'"
                                       " (cannot be 'input')", settings_block);
@@ -1151,7 +1151,7 @@ sw_ensemble_result_t sw_load_ensemble(const char* yaml_file,
   }
 
   FILE *file = fopen(yaml_file, "r");
-  if (file == NULL) {
+  if (!file) {
     result.error_code = SW_YAML_FILE_NOT_FOUND;
     result.error_message = new_string("The file '%s' could not be opened.",
                                       yaml_file);

--- a/src/tests/enumerated_test.F90
+++ b/src/tests/enumerated_test.F90
@@ -79,10 +79,8 @@ program enumeration_test
   type(input_result_t)    :: in_result
   type(input_t)           :: input
   type(output_t)          :: output
-  real(swp), dimension(:), allocatable :: array_val
   integer                 :: i
 
-  allocate(array_val(10))
   if (command_argument_count() /= 1) then
     print *, "enumeration_test_f90: usage:"
     print *, "enumeration_test_f90: <input.yaml>"
@@ -145,10 +143,6 @@ program enumeration_test
 
     ! Add a "qoi" metric set to 4.
     call output%set("qoi", 4.0_swp)
-    do i = 1,10
-      array_val(i) = i
-    end do
-    call output%set_array("qoi_array", array_val)
   end do
 
   ! Now we write out a Python module containing the output data.
@@ -156,5 +150,4 @@ program enumeration_test
 
   ! Clean up.
   call ensemble%free()
-  deallocate(array_val)
 end program

--- a/src/tests/lattice_test.F90
+++ b/src/tests/lattice_test.F90
@@ -80,7 +80,6 @@ program lattice_test
   type(input_t)           :: input
   type(input_result_t)    :: in_result
   type(output_t)          :: output
-  real(swp), dimension(:), allocatable :: array_val
   integer                 :: i
 
   if (command_argument_count() /= 1) then
@@ -89,7 +88,6 @@ program lattice_test
     stop
   end if
 
-  allocate(array_val(10))
   call get_command_argument(1, input_file)
 
   ! Print a banner with Skywalker's version info.
@@ -165,10 +163,6 @@ program lattice_test
 
     ! Add a "qoi" metric set to 4.
     call output%set("qoi", 4.0_swp)
-    do i = 1,10
-      array_val(i) = i
-    end do
-    call output%set_array("qoi_array", array_val)
   end do
 
   ! Now we write out a Python module containing the output data.
@@ -176,5 +170,4 @@ program lattice_test
 
   ! Clean up.
   call ensemble%free()
-  deallocate(array_val)
 end program

--- a/src/tests/mixed_test.F90
+++ b/src/tests/mixed_test.F90
@@ -80,7 +80,7 @@ program mixed_test
   type(input_t)           :: input
   type(input_result_t)    :: in_result
   type(output_t)          :: output
-  real(swp), dimension(:), allocatable :: array_val
+  real(swp)               :: qoi_array(10)
   integer                 :: i
 
   if (command_argument_count() /= 1) then
@@ -89,7 +89,6 @@ program mixed_test
     stop
   end if
 
-  allocate(array_val(10))
   call get_command_argument(1, input_file)
 
   ! Print a banner with Skywalker's version info.
@@ -154,10 +153,12 @@ program mixed_test
 
     ! Add a "qoi" metric set to 4.
     call output%set("qoi", 4.0_swp)
+
+    ! Add an array value.
     do i = 1,10
-      array_val(i) = i
+      qoi_array(i) = i-1
     end do
-    call output%set_array("qoi_array", array_val)
+    call output%set_array("qoi_array", qoi_array)
   end do
 
   ! Now we write out a Python module containing the output data.
@@ -165,5 +166,4 @@ program mixed_test
 
   ! Clean up.
   call ensemble%free()
-  deallocate(array_val)
 end program

--- a/src/tests/mixed_test.c
+++ b/src/tests/mixed_test.c
@@ -155,6 +155,13 @@ int main(int argc, char **argv) {
 
     // Add a "qoi" metric set to 4.
     sw_output_set(output, "qoi", 4.0);
+
+    // Add an array value.
+    sw_real_t qoi_array[10];
+    for (int i = 0; i < 10; ++i) {
+      qoi_array[i] = i;
+    }
+    sw_output_set_array(output, "qoi_array", qoi_array, 10);
   }
 
   // Write out a Python module.

--- a/src/tests/mixed_test.cpp
+++ b/src/tests/mixed_test.cpp
@@ -126,6 +126,13 @@ int main(int argc, char **argv) {
 
     // Add a "qoi" metric set to 4.
     output.set("qoi", 4.0);
+
+    // Add an array value.
+    std::vector<Real> qoi_array(10);
+    for (int i = 0; i < 10; ++i) {
+      qoi_array[i] = i;
+    }
+    output.set("qoi_array", qoi_array);
   });
 
   // Write out a Python module.


### PR DESCRIPTION
This commit also changes `sw_output_set_array` so the size parameter is a `size_t` and not a pointer. This required adding a small Fortran wrapper and updating the API documentation. 

We don't expect this change to be disruptive, because the C API is mostly being used to support the Fortran and C++ APIs at the moment.

The unit tests have been modified to produce bit-for-bit identical results in C, C++, and Fortran.

Finally, there are also a few small changes here and there in `skywalker.c` to make the C code a bit more "idiomatic".
