### PR TITLE
Added `make memcheck` target, which runs Valgrind on tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ else()
     if (HAVE_DOUBLE_PRECISION)
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wfloat-conversion")
     endif()
-    if (LINUX)
+    if (UNIX AND NOT APPLE)
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
     endif()
   elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
@@ -130,11 +130,27 @@ message(STATUS "Installation prefix is ${CMAKE_INSTALL_PREFIX}")
 # Third-party libs
 add_subdirectory(ext)
 
+# Support for valgrind (Linux only).
+if (UNIX AND NOT APPLE)
+  find_program(VALGRIND_EXE valgrind)
+  if (NOT VALGRIND_EXE MATCHES "NOTFOUND")
+    set(MEMORYCHECK_COMMAND ${Valgrind_EXE})
+    # Add "--gen-suppressions=all" to MEMORYCHECK_COMMAND_OPTIONS to generate
+    # suppressions for Valgrind's false positives. The suppressions show up
+    # right in the MemoryChecker.*.log files.
+    set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=definite,possible --track-origins=yes --error-exitcode=1 --trace-children=yes" CACHE STRING "Options passed to Valgrind." FORCE)
+
+    # make memcheck target
+    message(STATUS "Found valgrind. Enabling `make memcheck` target.")
+    add_custom_target(memcheck ctest -T memcheck USES_TERMINAL)
+  endif()
+endif()
+
 # Unit testing.
 include(CTest)
 enable_testing()
 
-# Generate skywalker.h and skywalker.cmake with the correct settings.
+# Generate skywalker.h with the correct settings.
 configure_file(
   ${PROJECT_SOURCE_DIR}/include/skywalker.h.in
   ${CMAKE_CURRENT_BINARY_DIR}/include/skywalker.h

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,6 +87,16 @@ you to consider.
     make test
     ```
 
+    If you're using Linux, you can also run Skywalker's tests through
+    [Valgrind](https://valgrind.org) to check for memory corruptions and leaks
+    with
+
+    ```
+    make memcheck
+    ```
+
+    (but be prepared to wait a while for the tests to finish).
+
     You should see several tests run (and hopefully pass!). Now, to install
     Skywalker to the path you specified with `CMAKE_INSTALL_PREFIX`, type
 

--- a/src/skywalker.c
+++ b/src/skywalker.c
@@ -918,6 +918,7 @@ static yaml_data_t parse_yaml(FILE* file, const char* settings_block) {
     handle_yaml_event(&event, &state, &data);
     if (data.error_code != SW_SUCCESS) {
       yaml_parser_delete(&parser);
+      yaml_event_delete(&event);
       goto return_data;
     }
     event_type = event.type;
@@ -1355,6 +1356,9 @@ void sw_ensemble_free(sw_ensemble_t *ensemble) {
       );
       kh_destroy(array_param_map, ensemble->inputs[i].array_params);
       kh_destroy(param_map, ensemble->outputs[i].metrics);
+      kh_foreach_value(ensemble->outputs[i].array_metrics, arrays,
+        kv_destroy(arrays);
+      );
       kh_destroy(array_param_map, ensemble->outputs[i].array_metrics);
     }
     free(ensemble->inputs);

--- a/src/skywalker.c
+++ b/src/skywalker.c
@@ -908,6 +908,7 @@ static yaml_data_t parse_yaml(FILE* file, const char* settings_block) {
     if (parser.error != YAML_NO_ERROR) {
       data.error_code = SW_INVALID_YAML;
       data.error_message = dup_string(parser.problem);
+      yaml_event_delete(&event);
       yaml_parser_delete(&parser);
       goto return_data;
     }
@@ -917,8 +918,8 @@ static yaml_data_t parse_yaml(FILE* file, const char* settings_block) {
     // to Skywalker's spec.
     handle_yaml_event(&event, &state, &data);
     if (data.error_code != SW_SUCCESS) {
-      yaml_parser_delete(&parser);
       yaml_event_delete(&event);
+      yaml_parser_delete(&parser);
       goto return_data;
     }
     event_type = event.type;

--- a/src/tests/enumerated_test.F90
+++ b/src/tests/enumerated_test.F90
@@ -79,7 +79,6 @@ program enumeration_test
   type(input_result_t)    :: in_result
   type(input_t)           :: input
   type(output_t)          :: output
-  integer                 :: i
 
   if (command_argument_count() /= 1) then
     print *, "enumeration_test_f90: usage:"

--- a/src/tests/lattice_test.F90
+++ b/src/tests/lattice_test.F90
@@ -80,7 +80,6 @@ program lattice_test
   type(input_t)           :: input
   type(input_result_t)    :: in_result
   type(output_t)          :: output
-  integer                 :: i
 
   if (command_argument_count() /= 1) then
     print *, "lattice_test_f90: usage:"


### PR DESCRIPTION
This target only works on Linux.

Found a few small memory leaks by running `make memcheck`. I don't think
we want to run this target in CI, though. Open to suggestions here.