### PR TITLE
Added the inline keyword to the banner printing function.

### DIFF
--- a/include/skywalker.hpp
+++ b/include/skywalker.hpp
@@ -60,7 +60,7 @@ class Exception : public std::exception {
 };
 
 // Prints a banner containing Skywalker's version info to stderr.
-void print_banner() {
+inline void print_banner() {
   sw_print_banner();
 }
 


### PR DESCRIPTION
This prevents the C++ compiler from generating multiple definitions for this
function. Given all the folklore about how the inline keyword "doesn't actually
do anything", this is pretty silly.