### PR TITLE
Use INT_MAX instead of -1 for uninitialized int flag.

### DIFF
--- a/src/skywalker.c
+++ b/src/skywalker.c
@@ -794,7 +794,7 @@ static void postprocess_array_params(khash_t(yaml_array_param_map) *params) {
       size_t len = kv_size(array_val0);
       if (len != kv_size(array_val1)) len = 0;
       if (len != kv_size(array_val2)) len = 0;
-      size_t size = -1;
+      size_t size = INT_MAX;
       for (size_t l = 0; l < len; ++l) {
         // find minimum distance from low to high.
         sw_real_t val0 = kv_A(array_val0, l),
@@ -803,13 +803,13 @@ static void postprocess_array_params(khash_t(yaml_array_param_map) *params) {
         if (val2 > 0) {
           if ((val0 < val1) && (val2 < val1)) {
             size_t s = (size_t)(ceil((val1 - val0) / val2) + 1);
-            if (s < size || -1 == size) size = s;
+            if (s < size || INT_MAX == size) size = s;
           } else {
             size = 0;
           }
         }
       }
-      if (size > 0) {
+      if (size > 0 && size != INT_MAX) {
         real_vec_vec_t expanded_array_values;
         kv_init(expanded_array_values);
         for (size_t i = 0; i < size; ++i) {

--- a/src/tests/validation_test.c
+++ b/src/tests/validation_test.c
@@ -168,6 +168,27 @@ static void test_empty_ensemble() {
   assert(load_result.error_message != NULL);
 }
 
+static void test_negative_values_issue_33() {
+  const char* bad_yaml = "\
+settings:  \n\
+  a: 1  \n\
+input:  \n\
+  enumerated:  \n\
+    Ns: [[0.0009478315467], [0.0008633937165], [0.01542388755]]  \n\
+    Temperature: [[-32.69480152], [-31.94781043], [-35.75495987]]  \n\
+    dt: [0.0, 0.0, 0.0]  \n\
+    w_vlc: [[0.2], [0.2], [0.2]]  \n\
+";
+  write_test_input(bad_yaml, "negative_values.yaml");
+  sw_ensemble_result_t load_result =
+    sw_load_ensemble("negative_values.yaml", "settings");
+  if (load_result.error_message)
+    printf("%s\n",load_result.error_message);
+  assert(load_result.error_code == SW_SUCCESS);
+  sw_ensemble_t *ensemble = load_result.ensemble;
+  assert(sw_ensemble_size(ensemble) == 3);
+}
+
 int main(int argc, char **argv) {
 
   // We ignore command line arguments in favor of programmatically generating
@@ -186,4 +207,5 @@ int main(int argc, char **argv) {
   test_too_many_lattice_params();
   test_invalid_enumeration();
   test_empty_ensemble();
+  test_negative_values_issue_33();
 }


### PR DESCRIPTION
Closes #33 