### PR TITLE
Fix for array parameter expansion

### DIFF
--- a/src/skywalker.c
+++ b/src/skywalker.c
@@ -794,7 +794,7 @@ static void postprocess_array_params(khash_t(yaml_array_param_map) *params) {
       size_t len = kv_size(array_val0);
       if (len != kv_size(array_val1)) len = 0;
       if (len != kv_size(array_val2)) len = 0;
-      size_t size = -1;
+      size_t size = 0;
       for (size_t l = 0; l < len; ++l) {
         // find minimum distance from low to high.
         sw_real_t val0 = kv_A(array_val0, l),

--- a/src/skywalker.c
+++ b/src/skywalker.c
@@ -803,7 +803,7 @@ static void postprocess_array_params(khash_t(yaml_array_param_map) *params) {
         if (val2 > 0) {
           if ((val0 < val1) && (val2 < val1)) {
             size_t s = (size_t)(ceil((val1 - val0) / val2) + 1);
-            if (s < size || -1 == size) size = s;
+            if (s < size || 0 == size) size = s;
           } else {
             size = 0;
           }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -20,6 +20,13 @@ foreach(test lattice_test enumerated_test mixed_test array_param_test)
   endif()
 endforeach()
 
+# Additional regression tests
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/nonexpandable_array_param_test.yaml
+  ${CMAKE_CURRENT_BINARY_DIR}/nonexpandable_array_param_test.yaml
+  COPYONLY)
+add_test(nonexpandable_array_param_test array_param_test nonexpandable_array_param_test.yaml)
+
 # Validation tests (currently C only).
 add_skywalker_driver(validation_test validation_test.c)
 add_test(validation_test validation_test)

--- a/src/tests/array_param_test.yaml
+++ b/src/tests/array_param_test.yaml
@@ -1,9 +1,7 @@
 # This input file tests Skywalker's support for array parameters.
 
 settings:
-  setting1: hello
-  setting2: 81
-  setting3: 3.14159265357
+  which: fixed_and_enumerated
 
 input:
   fixed:

--- a/src/tests/nonexpandable_array_param_test.yaml
+++ b/src/tests/nonexpandable_array_param_test.yaml
@@ -1,0 +1,12 @@
+# This input file tests that a given 3-item array parameter ISN'T expanded.
+
+settings:
+  which: nonexpandable_array
+
+input:
+  enumerated:
+    Ns: [[0.0009478315467], [0.0008633937165], [0.01542388755]]
+    Temperature: [[-32.69480152], [-31.94781043], [-35.75495987]] # <- this guy
+    dt: [0.0, 0.0, 0.0]
+    w_vlc: [[0.2], [0.2], [0.2]]
+


### PR DESCRIPTION
@overfelt , I just saw your PR. I guess I should watch everything on this site--I'm not in the habit of doing that. :-)

Here's what I ended up doing. I initialize the `size` parameter to `0` instead of `INT_MAX`, and I think it works properly. I also modified the C version of `array_param_test` to have it pick out this particular dataset. What do you think?

Closes #33 