### PR TITLE
Fixing a compilation error on Perlmutter.

### DIFF
--- a/examples/isotherms.c
+++ b/examples/isotherms.c
@@ -36,7 +36,6 @@
 #include <skywalker.h>
 
 #include <string.h>
-#include <tgmath.h>
 
 void usage() {
   fprintf(stderr, "isotherms_c: calculates the pressure of a Van der Waals gas "

--- a/src/tests/array_param_test.c
+++ b/src/tests/array_param_test.c
@@ -40,8 +40,7 @@
 
 #include <assert.h>
 #include <string.h>
-#include <tgmath.h>
-
+#include <math.h>
 void usage(const char *prog_name) {
   fprintf(stderr, "%s: usage:\n", prog_name);
   fprintf(stderr, "%s <input.yaml>\n", prog_name);

--- a/src/tests/enumerated_test.c
+++ b/src/tests/enumerated_test.c
@@ -40,7 +40,7 @@
 
 #include <assert.h>
 #include <string.h>
-#include <tgmath.h>
+#include <math.h>
 
 void usage(const char *prog_name) {
   fprintf(stderr, "%s: usage:\n", prog_name);

--- a/src/tests/lattice_test.c
+++ b/src/tests/lattice_test.c
@@ -40,7 +40,7 @@
 
 #include <assert.h>
 #include <string.h>
-#include <tgmath.h>
+#include <math.h>
 
 void usage(const char *prog_name) {
   fprintf(stderr, "%s: usage:\n", prog_name);

--- a/src/tests/mixed_test.c
+++ b/src/tests/mixed_test.c
@@ -40,7 +40,7 @@
 
 #include <assert.h>
 #include <string.h>
-#include <tgmath.h>
+#include <math.h>
 
 void usage(const char *prog_name) {
   fprintf(stderr, "%s: usage:\n", prog_name);


### PR DESCRIPTION
I am getting the following compilation error on Perlmutter: 
```
/usr/include/tgmath.h:54:4: error: 
#error 'Unsupported combination of types for <tgmath.h>.' 54 | 
# error 'Unsupported combination of types for <tgmath.h>.'
```

To fix it, I switched` #include <tgmath.h>` with `#include <math.h>`.