### PR TITLE
move project() call to squash warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,13 @@ cmake_minimum_required (VERSION 3.12.0)
 
 option(ENABLE_FORTRAN "Enable Skywalker Fortran library" ON)
 
+project (skywalker)
+
 enable_language(C)
 enable_language(CXX)
 if (ENABLE_FORTRAN)
   enable_language(Fortran)
 endif()
-
-project (skywalker)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
This is very minor, but I've been seeing a "developer warning" that complains about `enable_language()` calls should be after `project()` calls.

This does that 