### PR TITLE
Removing single quotes in Fortran comments to prevent ridiculous warnings.

### DIFF
--- a/examples/isotherms.F90
+++ b/examples/isotherms.F90
@@ -112,7 +112,7 @@ program isotherms
     V = input%get("V") ! gas (molar) volume [m3]
     T = input%get("T") ! gas temperature [K]
 
-    ! Fetch Van der Waals parameters if they're present.
+    ! Fetch Van der Waals parameters if present.
     a = 0.0_swp
     b = 0.0_swp
     if (input%has("a")) a = input%get("a")
@@ -121,7 +121,7 @@ program isotherms
     ! Compute p(V, T).
     p = R * T / (V - b) - a/(V**2)
 
-    ! Stash the computed pressure in the member's output.
+    ! Stash the computed pressure in member output.
     call output%set("p", p);
   end do
 

--- a/src/skywalker.F90
+++ b/src/skywalker.F90
@@ -36,7 +36,7 @@
 ! -------------------------------------------------------------------------
 
 ! This module contains data structures that allow Fortran modules to access
-! skywalker's ensemble input and output data.
+! skywalker ensemble input and output data.
 module skywalker
 
   use iso_c_binding
@@ -63,7 +63,7 @@ module skywalker
   integer, parameter :: sw_write_failure = 13
 
   ! This type represents an ensemble that has been loaded from a skywalker input
-  ! YAML file. It's an opaque type whose innards cannot be manipulated.
+  ! YAML file. It is an opaque type whose innards cannot be manipulated.
   type :: ensemble_t
     type(c_ptr)       :: ptr
     integer(c_size_t) :: size  ! number of members
@@ -158,7 +158,7 @@ module skywalker
     character(len=255) :: error_message
   end type ensemble_result_t
 
-  ! This type stores the result of an attempt to write an ensemble's data to
+  ! This type stores the result of an attempt to write an ensemble data to
   ! a Python module.
   type :: write_result_t
     integer(c_int)     :: error_code    ! error code indicating success or failure
@@ -272,7 +272,7 @@ module skywalker
 
 contains
 
-  ! Prints a banner containing Skywalker's version info to stderr.
+  ! Prints a banner containing Skywalker version info to stderr.
   subroutine print_banner()
     call sw_print_banner()
   end subroutine

--- a/src/tests/array_param_test.F90
+++ b/src/tests/array_param_test.F90
@@ -33,7 +33,7 @@
 ! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ! -------------------------------------------------------------------------
 
-! This program tests Skywalker's Fortran 90 interface and its support for
+! This program tests the Skywalker Fortran 90 interface and its support for
 ! array parameters.
 
 module array_param_test_mod
@@ -62,7 +62,7 @@ contains
   end function
 end module array_param_test_mod
 
-! This macro halts the program if the predicate x isn't true.
+! This macro halts the program if the predicate x is false.
 #define assert(x) if (.not. (x)) call fatal_error("Assertion failed at line", __LINE__)
 
 program array_param_test
@@ -87,7 +87,7 @@ program array_param_test
 
   call get_command_argument(1, input_file)
 
-  ! Print a banner with Skywalker's version info.
+  ! Print a banner with Skywalker version info.
   call print_banner()
 
   ! Load the ensemble. Any error encountered is fatal.

--- a/src/tests/enumerated_test.F90
+++ b/src/tests/enumerated_test.F90
@@ -33,7 +33,7 @@
 ! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ! -------------------------------------------------------------------------
 
-! This program tests Skywalker's Fortran 90 interface with a user-defined
+! This program tests the Skywalker Fortran 90 interface with a user-defined
 ! configuration that uses an "enumeration" ensemble.
 
 module enumeration_test_mod
@@ -62,7 +62,7 @@ contains
   end function
 end module enumeration_test_mod
 
-! This macro halts the program if the predicate x isn't true.
+! This macro halts the program if the predicate x is false.
 #define assert(x) if (.not. (x)) call fatal_error("Assertion failed at line", __LINE__)
 
 program enumeration_test
@@ -88,7 +88,7 @@ program enumeration_test
 
   call get_command_argument(1, input_file)
 
-  ! Print a banner with Skywalker's version info.
+  ! Print a banner with Skywalker version info.
   call print_banner()
 
   ! Load the ensemble. Any error encountered is fatal.
@@ -134,7 +134,7 @@ program enumeration_test
     assert(input%get("tock") >= 1e1_swp)
     assert(input%get("tock") <= 1e11_swp)
 
-    ! Look for a parameter that doesn't exist, checking its result by calling
+    ! Look for a parameter that does not exist, checking its result by calling
     ! get_param() instead of get().
     assert(.not. input%has("invalid_param"))
     in_result = input%get_param("invalid_param")

--- a/src/tests/lattice_test.F90
+++ b/src/tests/lattice_test.F90
@@ -33,7 +33,7 @@
 ! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ! -------------------------------------------------------------------------
 
-! This program tests Skywalker's Fortran 90 interface with a user-defined
+! This program tests the Skywalker Fortran 90 interface with a user-defined
 ! configuration.
 
 module lattice_test_mod
@@ -63,7 +63,7 @@ contains
   end function
 end module lattice_test_mod
 
-! This macro halts the program if the predicate x isn't true.
+! This macro halts the program if the predicate x is false.
 #define assert(x) if (.not. (x)) call fatal_error("Assertion failed at line", __LINE__)
 
 program lattice_test
@@ -89,7 +89,7 @@ program lattice_test
 
   call get_command_argument(1, input_file)
 
-  ! Print a banner with Skywalker's version info.
+  ! Print a banner with Skywalker version info.
   call print_banner()
 
   ! Load the ensemble. Any error encountered is fatal.
@@ -154,7 +154,7 @@ program lattice_test
     assert(input%get("sextet") >= 1)
     assert(input%get("sextet") <= 6)
 
-    ! Look for a parameter that doesn't exist, checking its result by calling
+    ! Look for a parameter that does not exist, checking its result by calling
     ! get_param() instead of get().
     assert(.not. input%has("invalid_param"))
     in_result = input%get_param("invalid_param")

--- a/src/tests/mixed_test.F90
+++ b/src/tests/mixed_test.F90
@@ -33,7 +33,7 @@
 ! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ! -------------------------------------------------------------------------
 
-! This program tests Skywalker's Fortran 90 interface with an ensemble
+! This program tests the Skywalker Fortran 90 interface with an ensemble
 ! containing both lattice and enumerated parameters.
 
 module mixed_test_mod
@@ -63,7 +63,7 @@ contains
   end function
 end module mixed_test_mod
 
-! This macro halts the program if the predicate x isn't true.
+! This macro halts the program if the predicate x is false.
 #define assert(x) if (.not. (x)) call fatal_error("Assertion failed at line", __LINE__)
 
 program mixed_test
@@ -91,7 +91,7 @@ program mixed_test
 
   call get_command_argument(1, input_file)
 
-  ! Print a banner with Skywalker's version info.
+  ! Print a banner with Skywalker version info.
   call print_banner()
 
   ! Load the ensemble. Any error encountered is fatal.
@@ -145,7 +145,7 @@ program mixed_test
     assert(input%get("e2") >= 0.05_swp)
     assert(input%get("e2") <= 0.3_swp)
 
-    ! Look for a parameter that doesn't exist, checking its result by calling
+    ! Look for a parameter that does not exist, checking its result by calling
     ! get_param() instead of get().
     assert(.not. input%has("invalid_param"))
     in_result = input%get_param("invalid_param")


### PR DESCRIPTION
Fortran compilers evidently care about the content in comments. I've always found it strange what that community finds important.